### PR TITLE
Fix skip entry bugs causing wrong conjunction query results

### DIFF
--- a/src/core/src/codecs/lucene104/Lucene104PostingsReader.cpp
+++ b/src/core/src/codecs/lucene104/Lucene104PostingsReader.cpp
@@ -374,8 +374,11 @@ int64_t Lucene104PostingsEnumWithImpacts::skipToTarget(int target) {
     }
 
     if (bestIdx >= 0) {
-        currentDoc_ = skipEntries_[bestIdx].doc - 1;  // Will advance to this doc
-        docsRead_ = (bestIdx + 1) * 128;              // Approximate docs read
+        // Skip entry stores: doc = last docID in skipped block, docFP = start of NEXT block.
+        // After skipping, currentDoc_ must equal entry.doc because the first delta
+        // in the next block is relative to the last doc of the previous (skipped) block.
+        currentDoc_ = skipEntries_[bestIdx].doc;
+        docsRead_ = (bestIdx + 1) * 128;              // Blocks 0..bestIdx are skipped
         currentSkipIndex_ = bestIdx;
         return skipEntries_[bestIdx].docFP;
     }

--- a/src/core/src/codecs/lucene104/Lucene104PostingsWriter.cpp
+++ b/src/core/src/codecs/lucene104/Lucene104PostingsWriter.cpp
@@ -108,7 +108,6 @@ void Lucene104PostingsWriter::startTerm() {
     // Reset block-level tracking for impacts
     blockMaxFreq_ = 0;
     blockMaxNorm_ = 0;
-    docsSinceLastSkip_ = 0;
     lastSkipDocFP_ = docStartFP_;
     lastSkipDoc_ = 0;
 
@@ -133,10 +132,6 @@ void Lucene104PostingsWriter::startDoc(int docID, int freq, int8_t norm) {
     // Track max frequency and norm for current block (for Block-Max WAND)
     blockMaxFreq_ = std::max(blockMaxFreq_, freq);
     blockMaxNorm_ = std::max(blockMaxNorm_, norm);
-    docsSinceLastSkip_++;
-
-    // Check if we need to create a skip entry
-    maybeFlushSkipEntry();
 
     // Buffer doc delta and frequency for StreamVByte encoding
     int docDelta = docID - lastDocID_;
@@ -206,17 +201,9 @@ TermState Lucene104PostingsWriter::finishTerm() {
         posBufferPos_ = 0;
     }
 
-    // Flush final skip entry if there are remaining docs
-    if (docsSinceLastSkip_ > 0 && !skipEntries_.empty()) {
-        // Only create final skip entry if we have a previous one
-        // (no point in single skip entry for small postings lists)
-        SkipEntry entry;
-        entry.doc = lastDocID_;
-        entry.docFP = docOut_->getFilePointer();
-        entry.maxFreq = blockMaxFreq_;
-        entry.maxNorm = blockMaxNorm_;
-        skipEntries_.push_back(entry);
-    }
+    // Note: No final skip entry for VInt tail. Skip entries only mark
+    // boundaries between PFOR blocks. The VInt tail is reached by scanning
+    // past the last PFOR block.
 
     // Write skip data to .skp file
     writeSkipData();
@@ -266,6 +253,23 @@ void Lucene104PostingsWriter::flushBuffer() {
     }
 
     bufferPos_ = 0;  // Reset buffer
+
+    // Create skip entry AFTER writing the PFOR block.
+    // entry.doc = last docID in this block (delta base for next block)
+    // entry.docFP = file position AFTER block = start of next block
+    // The reader uses docFP to seek to the start of the next block after skipping.
+    {
+        SkipEntry entry;
+        entry.doc = lastDocID_;
+        entry.docFP = docOut_->getFilePointer();
+        entry.maxFreq = blockMaxFreq_;
+        entry.maxNorm = blockMaxNorm_;
+        skipEntries_.push_back(entry);
+
+        // Reset for next block
+        blockMaxFreq_ = 0;
+        blockMaxNorm_ = 0;
+    }
 }
 
 void Lucene104PostingsWriter::flushPositionBuffer() {

--- a/src/core/src/codecs/lucene105/Lucene105PostingsWriter.cpp
+++ b/src/core/src/codecs/lucene105/Lucene105PostingsWriter.cpp
@@ -85,7 +85,6 @@ void Lucene105PostingsWriter::startTerm() {
     // Reset block-level tracking
     blockMaxFreq_ = 0;
     blockMaxNorm_ = 0;
-    docsSinceLastSkip_ = 0;
     lastSkipDocFP_ = docStartFP_;
     lastSkipDoc_ = 0;
 
@@ -110,10 +109,6 @@ void Lucene105PostingsWriter::startDoc(int docID, int freq, int8_t norm) {
     // Track max frequency and norm for current block
     blockMaxFreq_ = std::max(blockMaxFreq_, freq);
     blockMaxNorm_ = std::max(blockMaxNorm_, norm);
-    docsSinceLastSkip_++;
-
-    // Check if we need to create a skip entry
-    maybeFlushSkipEntry();
 
     // Buffer doc delta and frequency for StreamVByte encoding
     int docDelta = docID - lastDocID_;
@@ -169,17 +164,9 @@ TermState Lucene105PostingsWriter::finishTerm() {
         bufferPos_ = 0;
     }
 
-    // Flush final skip entry if there are remaining docs
-    if (docsSinceLastSkip_ > 0 && !skipEntries_.empty()) {
-        // Only create final skip entry if we have a previous one
-        // (no point in single skip entry for small postings lists)
-        SkipEntry entry;
-        entry.doc = lastDocID_;
-        entry.docFP = docOut_->getFilePointer();
-        entry.maxFreq = blockMaxFreq_;
-        entry.maxNorm = blockMaxNorm_;
-        skipEntries_.push_back(entry);
-    }
+    // Note: No final skip entry for VInt tail. Skip entries only mark
+    // boundaries between PFOR/StreamVByte blocks. The VInt tail is reached
+    // by scanning past the last encoded block.
 
     // Write skip data to .skp file
     writeSkipData();
@@ -247,6 +234,22 @@ void Lucene105PostingsWriter::flushBuffer() {
     }
 
     bufferPos_ = 0;  // Reset buffer
+
+    // Create skip entry AFTER writing the StreamVByte block.
+    // entry.doc = last docID in this block (delta base for next block)
+    // entry.docFP = file position AFTER block = start of next block
+    {
+        SkipEntry entry;
+        entry.doc = lastDocID_;
+        entry.docFP = docOut_->getFilePointer();
+        entry.maxFreq = blockMaxFreq_;
+        entry.maxNorm = blockMaxNorm_;
+        skipEntries_.push_back(entry);
+
+        // Reset for next block
+        blockMaxFreq_ = 0;
+        blockMaxNorm_ = 0;
+    }
 }
 
 void Lucene105PostingsWriter::close() {


### PR DESCRIPTION
## Summary

Two bugs in the skip entry implementation caused `advance()` to skip past target documents, producing wrong results for boolean MUST conjunction queries.

**Symptom**: ConjunctionScorer returns wrong results. For example, same-term AND (A MUST A) returns ~112K instead of ~384K on a 500K-doc index. Cross-field conjunction and impossible conjunction also return wrong counts. The bug triggers when doc ID gaps exceed 128 (skip threshold) in merged segments.

### Bug 1: Writer timing (Lucene104PostingsWriter, Lucene105PostingsWriter)

`maybeFlushSkipEntry()` was called in `startDoc()` BEFORE `flushBuffer()`, so `entry.docFP = docOut_->getFilePointer()` captured the file position **before** the PFOR block was written — pointing to the wrong block.

**Fix**: Move skip entry creation into `flushBuffer()` **after** the block is written to disk. Remove the premature `maybeFlushSkipEntry()` call from `startDoc()`. Also remove the final skip entry from `finishTerm()` since VInt tails don't need skip entries — they are reached by scanning past the last PFOR block.

### Bug 2: Reader delta base (Lucene104PostingsReader)

After skipping, `currentDoc_` was set to `skipEntries_[bestIdx].doc - 1`, but the first delta in the next block is relative to the last doc of the previous (skipped) block, so `currentDoc_` should equal `entry.doc` (without the `-1`).

**Fix**: Set `currentDoc_ = skipEntries_[bestIdx].doc` after skip.

## Skip entry semantics (corrected)

Each skip entry now stores:
- `doc`: Last docID in the flushed PFOR block (= delta base for next block)
- `docFP`: File position **after** the block = start of next block
- `maxFreq`, `maxNorm`: Block-max impact data for WAND

## Test plan

- [x] 500K-doc synthetic index (force-merged, Big5-like distribution):
  - Same-term conjunction: 100,000 PASS
  - Cross-field conjunction: 20,000 PASS  
  - Impossible conjunction: 0 PASS
  - `advance()` test: 0 errors (was 95% failure rate before fix)
- [x] 10M-doc Big5 benchmark through full distributed cluster:
  - Same-term conjunction matches single-term count exactly
  - Cross-field conjunction shows correct ~4% intersection
  - 39/42 benchmark queries pass

**Note**: Existing indices written with the buggy writer need re-indexing after this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)